### PR TITLE
Add support for Zalasr Extension

### DIFF
--- a/riscv-test-suite/env/test_macros.h
+++ b/riscv-test-suite/env/test_macros.h
@@ -615,6 +615,7 @@ Mend_PMP:                                    ;\
 #define TEST_JAL_OP(tempreg, rd, imm, label, swreg, offset, adj)	;\
 5:					;\
     LA(tempreg, 2f)			;\
+    mv rd, tempreg          ;\
     jalr x0,0(tempreg)			;\
 6:  LA(tempreg, 4f)			;\
     jalr x0,0(tempreg)			;\

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fld-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fld-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fld)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fld)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fldsp-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fldsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fldsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fldsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_SIGBASE(x1,signature_x1_1)

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsd-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsd-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fsd)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsd)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsdsp-01.S
+++ b/riscv-test-suite/rv32i_m/D_Zcd/src/c.fsdsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFDC,RV64IFDC")
+RVTEST_ISA("RV32IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*C.*);def TEST_CASE_1=True;",c.fsdsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsdsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.flw-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.flw-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flw)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flw)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.flwsp-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.flwsp-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flwsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.flwsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.fsw-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.fsw-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.fsw)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.fsw)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv32i_m/F_Zcf/src/c.fswsp-01.S
+++ b/riscv-test-suite/rv32i_m/F_Zcf/src/c.fswsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV32IFC")
+RVTEST_ISA("RV32IF_Zcf")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*C.*);def TEST_CASE_1=True;",c.fswsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV32.*I.*F.*Zcf.*);def TEST_CASE_1=True;",c.fswsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fld-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fld-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fld)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fld)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fldsp-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fldsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fldsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fldsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_SIGBASE(x1,signature_x1_1)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsd-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsd-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*F.*D.*C.*);def TEST_CASE_1=True;",c.fsd)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsd)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x3,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsdsp-01.S
+++ b/riscv-test-suite/rv64i_m/D_Zcd/src/c.fsdsp-01.S
@@ -19,7 +19,7 @@
 // 
 #include "model_test.h"
 #include "arch_test.h"
-RVTEST_ISA("RV64IFDC")
+RVTEST_ISA("RV64IFD_Zcd")
 
 .section .text.init
 .globl rvtest_entry_point
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*D.*C.*);def TEST_CASE_1=True;",c.fsdsp)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*F.*D.*Zcd.*);def TEST_CASE_1=True;",c.fsdsp)
 
 RVTEST_FP_ENABLE()
 RVTEST_VALBASEUPD(x4,test_dataset_0)

--- a/riscv-test-suite/rv64i_m/I/src/sra-01.S
+++ b/riscv-test-suite/rv64i_m/I/src/sra-01.S
@@ -29,7 +29,7 @@ RVTEST_CODE_BEGIN
 
 #ifdef TEST_CASE_1
 
-RVTEST_CASE(0,"//check ISA:=regex(.*I.*);def TEST_CASE_1=True;",sra)
+RVTEST_CASE(0,"//check ISA:=regex(.*RV64.*I.*);def TEST_CASE_1=True;",sra)
 
 RVTEST_SIGBASE(x1,signature_x1_1)
 


### PR DESCRIPTION
<FOR DOC UPDATES FILL ONLY DESCRIPTION AND RELATED ISSUES SECTION AND REMOVE THE OTHERS>

## Description

> Add support for Zalasr extension

### Related Issues

> NA

### Ratified/Unratified Extensions

- [ ] Ratified
- [x] Unratified

### List Extensions

> Zalasr (https://github.com/riscv/riscv-zalasr)

### Reference Model Used

- [ ] SAIL
- [ ] Spike
- [ ] Other - < SPECIFY HERE >

### Mandatory Checklist:

  - [x] All tests are compliant with the test-format spec present in this repo ?
  - [ ] Ran the new tests on RISCOF with SAIL/Spike as reference model successfully ?
  - [ ] Ran the new tests on RISCOF in [coverage mode](https://riscof.readthedocs.io/en/stable/commands.html#coverage)
  - [ ] Link to Google-Drive folder containing the new coverage reports ([See this](https://github.com/riscv-non-isa/riscv-arch-test/blob/main/CONTRIBUTION.md#uploading-test-stats) for more info): < SPECIFY HERE >

### Optional Checklist:

  - [ ] Were the tests hand-written/modified ?
  - [ ] Have you run these on any hard DUT model ? Please specify name and provide link if possible in the description
  - [ ] If you have modified arch\_test.h Please provide a detailed description of the changes in the Description section above.

Can't run tests since following the directions at https://riscv-ctg.readthedocs.io/en/latest/cli.html#running-the-test-generator does not work.
